### PR TITLE
Add parent error class and spec coverage

### DIFF
--- a/lib/raiblocks_rpc/errors.rb
+++ b/lib/raiblocks_rpc/errors.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 module RaiblocksRpc
-  class BadRequest < StandardError; end
-  class InvalidRequest < StandardError; end
-  class InvalidParameterType < StandardError; end
-  class ForbiddenParameter < StandardError; end
-  class MissingParameters < StandardError; end
+  class Error < StandardError; end
+
+  class BadRequest < Error; end
+  class InvalidRequest < Error; end
+  class InvalidParameterType < Error; end
+  class ForbiddenParameter < Error; end
+  class MissingParameters < Error; end
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe 'RaiblocksRpc errors' do
+  describe RaiblocksRpc::Error do
+    it 'is a StandardError' do
+      expect(subject).to be_a StandardError
+    end
+  end
+
+  shared_examples 'child error' do
+    it 'is a RaiblocksRpc::Error' do
+      expect(subject).to be_a RaiblocksRpc::Error
+    end
+  end
+
+  describe RaiblocksRpc::BadRequest do
+    include_examples 'child error'
+  end
+  describe RaiblocksRpc::InvalidRequest do
+    include_examples 'child error'
+  end
+  describe RaiblocksRpc::InvalidParameterType do
+    include_examples 'child error'
+  end
+  describe RaiblocksRpc::ForbiddenParameter do
+    include_examples 'child error'
+  end
+  describe RaiblocksRpc::MissingParameters do
+    include_examples 'child error'
+  end
+end


### PR DESCRIPTION
Adds `RaiblocksRpc::Error` as a parent for all errors in the gem, and spec coverage (right now just tests inheritance).

`bundle exec rspec spec/errors_spec.rb --format documentation` provides a handy list of all errors the gem might produce :)