### PR TITLE
Add empty module

### DIFF
--- a/lib/raiblocks_rpc.rb
+++ b/lib/raiblocks_rpc.rb
@@ -10,3 +10,6 @@ require 'raiblocks_rpc/proxies/network'
 require 'raiblocks_rpc/proxies/node'
 require 'raiblocks_rpc/proxies/util'
 require 'raiblocks_rpc/proxies/wallet'
+
+module RaiblocksRpc
+end


### PR DESCRIPTION
No functional changes, just adds an empty module block to the top-level file so the module definition is explicit rather than implicit.